### PR TITLE
RD-server: don't set OTHER flag if the DHCP server is not running

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -269,7 +269,10 @@ static void send_router_advert(struct relayd_event *event)
 		.lladdr = {ND_OPT_SOURCE_LINKADDR, 1, {0}},
 		.mtu = {ND_OPT_MTU, 1, 0, htonl(mtu)},
 	};
-	adv.h.nd_ra_flags_reserved = ND_RA_FLAG_OTHER;
+
+	if (config->enable_dhcpv6_server) // Announce stateless DHCP
+	  adv.h.nd_ra_flags_reserved = ND_RA_FLAG_OTHER;
+
 	if (config->ra_managed_mode >= RELAYD_MANAGED_MFLAG)
 		adv.h.nd_ra_flags_reserved |= ND_RA_FLAG_MANAGED;
 


### PR DESCRIPTION
The RD-server sets ND_RA_FLAG_OTHER even if the DHCP server is
not runnng, causing hosts on the link to fire a dhcp client and
try to get additional configuration parameters forever.

This is mostly harmless as SLAAC is working as expected (with DNS
addresses obtained through RAs), but generates unnecessary multicast
traffic on the link.

This commit fixes it by only setting the flag when the dhcp server
is running.
